### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Version 1.0.0
 
 ![Demo 3](demo3.gif)
 
-##Installation
+## Installation
 
 * CocoaPods add `pod 'CXCardView'`
 
 
-##How to use
+## How to use
 
 ```Objective-C
 + (CXCardView *)showWithView:(UIView *)view draggable:(BOOL)draggable;
@@ -28,21 +28,21 @@ Version 1.0.0
 - (void)dismiss;
 ```
 
-##Next
+## Next
  * Support custom animation
 
-##Support
+## Support
  * Xcode 5
  * ARC
 
-##Contact
+## Contact
 #### Chris Xu
 
  * [@GitHub](https://github.com/ChrisXu1221)
  * [@Twitter](https://twitter.com/taterctl)
  * [@Mail](mailto:taterctl@gmail.com)
  
-##License
+## License
 Copyright (c) 2013 Chris Xu, Licensed under the MIT license (http://www.opensource.org/licenses/mit-license.php)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ‘Software’), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
